### PR TITLE
hotfix: delete apiServcie on DropDown

### DIFF
--- a/frontend/src/components/DropDown.vue
+++ b/frontend/src/components/DropDown.vue
@@ -19,7 +19,6 @@ import {
   Component,
 } from 'vue-property-decorator';
 import AuthService from '../service/AuthService';
-import apiService from '../service/apiService';
 
 @Component
 export default class DropDown extends Vue {
@@ -36,11 +35,6 @@ export default class DropDown extends Vue {
 
   goPage(res:string): void {
     this.$router.push(res);
-  }
-
-  async apiTest() {
-    var a = await new apiService().defaultGet('/api/user/test');
-    console.log(a);
   }
 }
 


### PR DESCRIPTION
apiService 변경으로 인해 개발 서버 실행 에러 발생.
드롭다운 컴포넌트에 있는 apiService 빠르게 삭제 핫픽스.
DetailOrderView.vue 또한 발생하는데 동륜이가 직접해주길 바람.